### PR TITLE
Configure long method code smell

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,7 @@ version: "2"
 checks:
   method-lines:
     enabled: false # we already check line count with detekt
+exclude_patterns:
+- "**/test/"
+- "**/androidTest/"
+- "**test

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,6 @@ checks:
   method-lines:
     enabled: false # we already check line count with detekt
 exclude_patterns:
-- "**/test/"
-- "**/androidTest/"
-- "**test
+ - "**/test/"
+ - "**/androidTest/"
+ - "**test

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,6 @@ checks:
   method-lines:
     enabled: false # we already check line count with detekt
 exclude_patterns:
- - "**/test/"
- - "**/androidTest/"
- - "**test
+  - "**/test/"
+  - "**/androidTest/"
+  - "**test"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
-exclude_patterns:
-- "**/test/"
-- "**/androidTest/"
-- "**test"
+version: "2"
+checks:
+  method-lines:
+    enabled: false # we already check line count with detekt

--- a/detekt.yml
+++ b/detekt.yml
@@ -134,7 +134,11 @@ complexity:
   LongMethod:
     active: true
     threshold: 30
-    ignoreAnnotated: []
+    ignoreAnnotated: 
+    excludes:
+     [
+       "**/ui/**",
+     ]
   LongParameterList:
     active: false
     functionThreshold: 6
@@ -885,7 +889,7 @@ style:
       - "1"
       - "2"
     ignoreHashCodeFunction: true
-    ignorePropertyDeclaration: false
+    ignorePropertyDeclaration: true
     ignoreLocalVariableDeclaration: false
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true


### PR DESCRIPTION
This pull request reconfigures codeclimate and detekt: 
* The long method check can be excluded from codeclimate, because it's already checked via detekt
* For composable functions it doesn't make sense to have a hard limit of 30 lines per function. Unfortunately, we can't exclude code from the detekt analysis by the `@composable` annotation. As a workaround we don't apply the check to the ui package.