### PR TITLE
Fix issues with tests randomly failing on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 container:
   image: cirrusci/android-sdk:30
-  cpu: 4
+  cpu: 8
   memory: 16G
   kvm: true
 


### PR DESCRIPTION
In the last week we added a good amount of new test cases to the repo. Since then some commits are not passing the CI because of tests randomly failing. Unfortunately, I can't really reproduce the failure on my local machine, so I make guess that it's due to a lack of performance of the container. Let's see after the merge, if the change fixed the problem.