### PR TITLE
show given event with event uid

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventScreenTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventScreenTest.kt
@@ -37,6 +37,7 @@ class DetailedEventScreenTest {
     private val calendar = Calendar.getInstance()
     private lateinit var testEvent: Event
     private lateinit var eventDate: String
+    private lateinit var eventId: String
 
     @Before
     fun setUp() {
@@ -95,13 +96,14 @@ class DetailedEventScreenTest {
             auth.signInWithEmailAndPassword("harry.potter@epfl.ch", "123456").await()
         }
         runBlocking {
-            firestore.collection(EVENT_PATH).document(testEvent.id).set(eventMap).await()
+            val documentReference = firestore.collection(EVENT_PATH).add(eventMap).await()
+            eventId = documentReference.id
         }
     }
     @After
     fun cleanUp() {
         runBlocking {
-            firestore.collection(EVENT_PATH).document("harry.potter@epfl.ch").delete().await()
+            firestore.collection(EVENT_PATH).document(eventId).delete().await()
             auth.signInWithEmailAndPassword("harry.potter@epfl.ch", "123456").await()
             auth.currentUser?.delete()?.await()
         }
@@ -110,7 +112,7 @@ class DetailedEventScreenTest {
     @Test
     fun testCorrectDetailedEventInfoIsDisplayed() {
         composeTestRule.setContent {
-            DetailedEventScreen()
+            DetailedEventScreen(eventId)
         }
         composeTestRule.waitUntil(timeoutMillis = 5000) {
             composeTestRule

--- a/app/src/main/java/ch/epfl/sdp/cook4me/Cook4MeApp.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/Cook4MeApp.kt
@@ -136,7 +136,8 @@ fun Cook4MeApp(
         composable(route = Screen.EditProfileScreen.name) { EditProfileScreen() }
         composable(route = Screen.CreateTupperwareScreen.name) { CreateTupperwareScreen() }
         composable(route = Screen.CreateEventScreen.name) { CreateEventScreen() }
-        composable(route = Screen.DetailedEventScreen.name) { DetailedEventScreen() }
+        // the uid of event is predefined on firestore. this is just for show.
+        composable(route = Screen.DetailedEventScreen.name) { DetailedEventScreen("IcxAvzg7RfckSxw9K5I0") }
         composable(route = Screen.SignUpScreen.name) {
             SignUpScreen(
                 onSuccessfullSignUp = { navController.navigate(Screen.SignUpUserInfos.name) },

--- a/app/src/main/java/ch/epfl/sdp/cook4me/application/EventFormService.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/application/EventFormService.kt
@@ -49,8 +49,6 @@ class EventFormService(private val objectRepository: ObjectRepository = ObjectRe
     * */
     suspend fun getEventWithId(id: String): Event? {
         val result = objectRepository.getWithId<Event>(id)
-        // if(result == null) println("YESSSSSSSSSSSSSS")
-        // result?.let { println("NOOOOOOOOOOOO") }
         return result?.let { documentSnapshotToEvent(it) }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/cook4me/application/EventFormService.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/application/EventFormService.kt
@@ -44,6 +44,17 @@ class EventFormService(private val objectRepository: ObjectRepository = ObjectRe
     }
 
     /*
+    * To get the event of given id.
+    * If nothing is found, null is returned
+    * */
+    suspend fun getEventWithId(id: String): Event? {
+        val result = objectRepository.getWithId<Event>(id)
+        // if(result == null) println("YESSSSSSSSSSSSSS")
+        // result?.let { println("NOOOOOOOOOOOO") }
+        return result?.let { documentSnapshotToEvent(it) }
+    }
+
+    /*
     * Notes: Firebase could not serialize to java.untl.Calender, I will add an constructor in Event.kt
     * to construct an Event object from a map.
     * This function is used to convert a document snapshot to an event object manually.

--- a/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/ObjectRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/ObjectRepository.kt
@@ -70,4 +70,19 @@ open class ObjectRepository(
             Log.e("ObjectRepo", "Error querying documents: ${e.message}")
             emptyList()
         }
+
+    /*
+    * This function is designed with cope with the Event data class, though it's still generic.
+    * Instead of calling .toObject(), it simply returns the DocumentSnapshot, and we deal with
+    * it later.
+    * If nothing is found, it returns null.
+    * */
+    suspend fun <A : Any> getWithId(id: String): DocumentSnapshot? =
+        try {
+            val result = store.collection(objectPath).document(id).get().await()
+            result
+        } catch (e: FirebaseFirestoreException) {
+            Log.e("ObjectRepo", "Error querying documents: ${e.message}")
+            null
+        }
 }

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventScreen.kt
@@ -2,19 +2,21 @@ package ch.epfl.sdp.cook4me.ui.detailedevent
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.epfl.sdp.cook4me.R
 
 /**
@@ -22,46 +24,54 @@ import ch.epfl.sdp.cook4me.R
  */
 @Composable
 fun DetailedEventScreen(
-    detailedEventViewModel: DetailedEventViewModel = viewModel(),
+    eventId: String,
+    detailedEventViewModel: DetailedEventViewModel = DetailedEventViewModel(eventId),
 ) {
-    val event = detailedEventViewModel.firstEventState.value
-    Column(
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp)
-            .background(MaterialTheme.colors.background)
-    ) {
-        SectionWithTitle(title = stringResource(R.string.event_name), content = event.name)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+    val event = detailedEventViewModel.eventState.value
+    val isLoading = detailedEventViewModel.isLoading.value
+    Box {
+        if (isLoading) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        } else {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+                    .background(MaterialTheme.colors.background)
+            ) {
+                SectionWithTitle(title = stringResource(R.string.event_name), content = event.name)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(title = stringResource(R.string.event_description), content = event.description)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(title = stringResource(R.string.event_description), content = event.description)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(title = stringResource(R.string.event_location), content = event.location)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(title = stringResource(R.string.event_location), content = event.location)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(
-            title = stringResource(R.string.event_max_participants),
-            content = event.maxParticipants.toString()
-        )
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(
+                    title = stringResource(R.string.event_max_participants),
+                    content = event.maxParticipants.toString()
+                )
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(title = stringResource(R.string.event_creator), content = event.creator)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(title = stringResource(R.string.event_creator), content = event.creator)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(
-            title = stringResource(R.string.event_participants),
-            content = event.participants.joinToString(separator = ", ")
-        )
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(
+                    title = stringResource(R.string.event_participants),
+                    content = event.participants.joinToString(separator = ", ")
+                )
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        val accessibility = if (event.isPrivate) "Only Subscribers" else "Everyone"
-        SectionWithTitle(title = stringResource(R.string.event_who_can_see_event), content = accessibility)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                val accessibility = if (event.isPrivate) "Only Subscribers" else "Everyone"
+                SectionWithTitle(title = stringResource(R.string.event_who_can_see_event), content = accessibility)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
 
-        SectionWithTitle(title = stringResource(R.string.event_time), content = event.eventDate)
-        Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+                SectionWithTitle(title = stringResource(R.string.event_time), content = event.eventDate)
+                Divider(color = MaterialTheme.colors.secondary, thickness = 1.dp)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventViewModel.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/detailedevent/DetailedEventViewModel.kt
@@ -1,28 +1,31 @@
 package ch.epfl.sdp.cook4me.ui.detailedevent
 
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import ch.epfl.sdp.cook4me.application.AccountService
 import ch.epfl.sdp.cook4me.application.EventFormService
 import ch.epfl.sdp.cook4me.ui.eventform.Event
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class DetailedEventViewModel(
+    eventId: String,
     eventService: EventFormService = EventFormService(),
-    accountService: AccountService = AccountService()
 ) : ViewModel() {
-    private val _firstEventState = mutableStateOf<Event>(Event())
-    val firstEventState
-        get() = _firstEventState
+    private val _eventState = mutableStateOf(Event())
+    val eventState: State<Event> = _eventState
+    private val _isLoading = mutableStateOf(true)
+    val isLoading: State<Boolean> = _isLoading
 
     init {
         viewModelScope.launch {
-            val userEmail = accountService.getCurrentUserEmail()
-            userEmail?.let {
-                val firstEvent = eventService.getFirstEventWithGivenField("id", userEmail)
-                firstEvent?.let {
-                    _firstEventState.value = it
+            val eventQueried = eventService.getEventWithId(eventId)
+            eventQueried?.let {
+                withContext(Dispatchers.Main) {
+                    _eventState.value = it
+                    _isLoading.value = false
                 }
             }
         }


### PR DESCRIPTION
I changed the previous detailedEventScreen to allow it to take the uid of an event on firestore as input, and displaying the actual event. The detailed event feature is now no longer dependent on the account service (which is good!)

I also added a circular waiting bar in the screen to indicate the data is still being retrieved in case of slow network connection. This is also the potential solution to "Correct profile info randomly showing" issue we found on Friday morning.

Usage:  DetailedEventScreen("someId")

Took me ~3 hours.