### PR TITLE
Fix/get rid of overview in chat nav

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/cook4me/Cook4MeApp.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/Cook4MeApp.kt
@@ -207,7 +207,7 @@ fun Cook4MeApp(
         }
         composable(route = Screen.ChatScreen.name) {
             ChannelScreen(
-                onBackListener = { navController.navigate(Screen.OverviewScreen.name) },
+                onBackListener = { navController.navigate(Screen.RecipeFeed.name) },
             )
         }
     }


### PR DESCRIPTION
Previous code couldn't function: when I open chat, go back, and hit chat button again, the app doesn't navigate to the chat screen any more, but to the overview screen (weird).
I changed to navigate back to the recipe feed screen, seems to have solved the problem.