### PR TITLE
sketch a draft how we can profile images

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ChannelScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ChannelScreen.kt
@@ -1,8 +1,10 @@
 package ch.epfl.sdp.cook4me.ui.chat
 
+import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -12,13 +14,24 @@ import androidx.core.content.ContextCompat.startActivity
 import ch.epfl.sdp.cook4me.BuildConfig
 import ch.epfl.sdp.cook4me.R
 import ch.epfl.sdp.cook4me.application.AccountService
+import ch.epfl.sdp.cook4me.persistence.repository.ProfileImageRepository
 import ch.epfl.sdp.cook4me.ui.common.LoadingScreen
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
+import coil.ComponentRegistry
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.DefaultRequestOptions
+import coil.request.Disposable
+import coil.request.ImageRequest
+import coil.request.ImageResult
+import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
 import io.getstream.chat.android.compose.ui.channels.ChannelsScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
-import kotlinx.coroutines.runBlocking
+import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoaderFactory
+
 
 // TODO: Refactor needed: https://github.com/cook4me/android/issues/155
 @Composable
@@ -30,11 +43,7 @@ fun ChannelScreen(
     accountService: AccountService = AccountService(),
     onBackListener: () -> Unit = {},
 ) {
-    // disconnecting the client before connecting again, otherwise will
-    // cause error: too many connections
-    runBlocking {
-        client.disconnect(true).enqueue()
-    }
+
     val context = LocalContext.current
     val userEmail = accountService.getCurrentUserWithEmail()
     val fullName = remember { mutableStateOf("") }
@@ -42,19 +51,28 @@ fun ChannelScreen(
     val user = remember {
         mutableStateOf(User(id = fullName.value))
     }
-    // The user email is always not null, it's a bit of boilerplate.
-    userEmail?.let { email ->
-        // parsing email to get the name (user id)
-        val nameParts = email.split("@")[0].replace(".", "")
-        fullName.value = nameParts.trim()
-        user.value = User(id = fullName.value)
-        // generating user token and connecting the user
-        val token = client.devToken(user.value.id)
-        client.connectUser(user.value, token).enqueue { result ->
-            if (result.isSuccess) {
-                isConnected.value = true
-            } else {
-                println("connection not successful")
+
+    // TODO: I would have preferred to use LaunchedEffect instead of a callback chain
+    client.disconnect(true).enqueue { disconnectResult ->
+        if (disconnectResult.isSuccess) {
+            // disconnecting the client before connecting again, otherwise will
+            // cause error: too many connections
+            // The user email is always not null, it's a bit of boilerplate.
+            userEmail?.let { email ->
+                // parsing email to get the name (user id)
+                val nameParts = email.split("@")[0].replace(".", "")
+                fullName.value = nameParts.trim()
+                user.value = User(id = fullName.value, image = "${PROFILE_IMAGE_PREFIX}$email")
+                // generating user token and connecting the user
+                val token = client.devToken(user.value.id)
+                client.connectUser(user.value, token).enqueue { result ->
+                    if (result.isSuccess) {
+                        isConnected.value = true
+                    } else {
+                        //TODO: use Log.e(...) instead
+                        println("connection not successful")
+                    }
+                }
             }
         }
     }
@@ -65,7 +83,7 @@ fun ChannelScreen(
             .testTag(context.getString(R.string.Channel_Screen_Tag))
     ) {
         if (isConnected.value) {
-            ChatTheme {
+            ChatTheme(imageLoaderFactory = CoilImageLoaderFactory) {
                 ChannelsScreen(
                     filters = Filters.and(
                         Filters.eq("type", "messaging"),
@@ -80,9 +98,7 @@ fun ChannelScreen(
                         startActivity(context, intent, null)
                     },
                     onBackPressed = { onBackListener() },
-                    onHeaderAvatarClick = {
-                        client.disconnect(true).enqueue()
-                    },
+                    isShowingHeader = false
                 )
             }
         } else {

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ChannelScreen.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ChannelScreen.kt
@@ -1,10 +1,8 @@
 package ch.epfl.sdp.cook4me.ui.chat
 
-import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -14,24 +12,12 @@ import androidx.core.content.ContextCompat.startActivity
 import ch.epfl.sdp.cook4me.BuildConfig
 import ch.epfl.sdp.cook4me.R
 import ch.epfl.sdp.cook4me.application.AccountService
-import ch.epfl.sdp.cook4me.persistence.repository.ProfileImageRepository
 import ch.epfl.sdp.cook4me.ui.common.LoadingScreen
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
-import coil.ComponentRegistry
-import coil.ImageLoader
-import coil.disk.DiskCache
-import coil.memory.MemoryCache
-import coil.request.DefaultRequestOptions
-import coil.request.Disposable
-import coil.request.ImageRequest
-import coil.request.ImageResult
-import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
 import io.getstream.chat.android.compose.ui.channels.ChannelsScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
-import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoaderFactory
-
 
 // TODO: Refactor needed: https://github.com/cook4me/android/issues/155
 @Composable
@@ -43,7 +29,6 @@ fun ChannelScreen(
     accountService: AccountService = AccountService(),
     onBackListener: () -> Unit = {},
 ) {
-
     val context = LocalContext.current
     val userEmail = accountService.getCurrentUserWithEmail()
     val fullName = remember { mutableStateOf("") }
@@ -69,7 +54,7 @@ fun ChannelScreen(
                     if (result.isSuccess) {
                         isConnected.value = true
                     } else {
-                        //TODO: use Log.e(...) instead
+                        // TODO: use Log.e(...) instead
                         println("connection not successful")
                     }
                 }

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/CoilImageLoaderFactory.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/CoilImageLoaderFactory.kt
@@ -1,0 +1,35 @@
+package ch.epfl.sdp.cook4me.ui.chat
+
+import android.content.Context
+import coil.ImageLoader
+import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
+import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoaderFactory
+
+//  adapted getstream's DefaultStreamCoilImageLoaderFactory
+internal object CoilImageLoaderFactory : StreamCoilImageLoaderFactory {
+
+    /**
+     * Loads images in the app, with our default settings.
+     */
+    private var imageLoader: ImageLoader? = null
+
+    /**
+     * Returns either the currently available [ImageLoader] or builds a new one.
+     *
+     * @param context - The [Context] to build the [ImageLoader] with.
+     * @return [ImageLoader] that loads images in the app.
+     */
+    override fun imageLoader(context: Context): ImageLoader = imageLoader ?: newImageLoader(context)
+
+    /**
+     * Builds a new [ImageLoader] using the given Android [Context]. If the loader already exists, we return it.
+     *
+     * @param context - The [Context] to build the [ImageLoader] with.
+     * @return [ImageLoader] that loads images in the app.
+     */
+    @Synchronized
+    private fun newImageLoader(context: Context): ImageLoader {
+        imageLoader?.let { return it }
+        return ImageLoaderDecorator(StreamImageLoaderFactory(context).newImageLoader())
+    }
+}

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ImageLoaderDecorator.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ImageLoaderDecorator.kt
@@ -25,14 +25,12 @@ internal class ImageLoaderDecorator(
     override val memoryCache: MemoryCache?
         get() = loader.memoryCache
 
-    override fun enqueue(request: ImageRequest): Disposable {
-        return loader.enqueue(request)
-    }
+    override fun enqueue(request: ImageRequest): Disposable = loader.enqueue(request)
 
     // Unfortunately, there doesn't exist a way to store an image for each chat user
     // This is a workaround to load images related to the chat either from the profile data or from getstream
-    override suspend fun execute(request: ImageRequest): ImageResult {
-        return if (request.data is String && (request.data as String).startsWith(
+    override suspend fun execute(request: ImageRequest): ImageResult =
+        if (request.data is String && (request.data as String).startsWith(
                 PROFILE_IMAGE_PREFIX
             )
         ) {
@@ -49,13 +47,8 @@ internal class ImageLoaderDecorator(
         } else {
             loader.execute(request)
         }
-    }
 
-    override fun newBuilder(): ImageLoader.Builder {
-        return loader.newBuilder()
-    }
+    override fun newBuilder(): ImageLoader.Builder = loader.newBuilder()
 
-    override fun shutdown() {
-        loader.shutdown()
-    }
+    override fun shutdown() = loader.shutdown()
 }

--- a/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ImageLoaderDecorator.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/ui/chat/ImageLoaderDecorator.kt
@@ -1,0 +1,61 @@
+package ch.epfl.sdp.cook4me.ui.chat
+
+import ch.epfl.sdp.cook4me.persistence.repository.ProfileImageRepository
+import coil.ComponentRegistry
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.DefaultRequestOptions
+import coil.request.Disposable
+import coil.request.ImageRequest
+import coil.request.ImageResult
+
+const val PROFILE_IMAGE_PREFIX = "load profile image"
+
+internal class ImageLoaderDecorator(
+    private val loader: ImageLoader,
+    private val profileImageRepository: ProfileImageRepository = ProfileImageRepository()
+) : ImageLoader {
+    override val components: ComponentRegistry
+        get() = loader.components
+    override val defaults: DefaultRequestOptions
+        get() = loader.defaults
+    override val diskCache: DiskCache?
+        get() = loader.diskCache
+    override val memoryCache: MemoryCache?
+        get() = loader.memoryCache
+
+    override fun enqueue(request: ImageRequest): Disposable {
+        return loader.enqueue(request)
+    }
+
+    // Unfortunately, there doesn't exist a way to store an image for each chat user
+    // This is a workaround to load images related to the chat either from the profile data or from getstream
+    override suspend fun execute(request: ImageRequest): ImageResult {
+        return if (request.data is String && (request.data as String).startsWith(
+                PROFILE_IMAGE_PREFIX
+            )
+        ) {
+            val image = profileImageRepository.getProfile(
+                (request.data as String).removePrefix(
+                    PROFILE_IMAGE_PREFIX
+                )
+            )
+            loader.execute(
+                ImageRequest.Builder(request.context)
+                    .data(image)
+                    .build()
+            )
+        } else {
+            loader.execute(request)
+        }
+    }
+
+    override fun newBuilder(): ImageLoader.Builder {
+        return loader.newBuilder()
+    }
+
+    override fun shutdown() {
+        loader.shutdown()
+    }
+}


### PR DESCRIPTION
This PR sketches a solution how we can load the profile image for the chat feature. Unfortunately, we can't store them on the getstream server, so we need to implement a workaround. There is also a potential race condition I tried to fix in the ChannelScreen (`client.disconnect(...)` should probably always be executed / terminated before `client.connectUser(...)`)