### PR TITLE
extend firebase functions to be able to use custom mapper

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/ChallengeRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/ChallengeRepository.kt
@@ -10,7 +10,11 @@ class ChallengeRepository(private val store: FirebaseFirestore = FirebaseFiresto
         store.addObjectToCollection(challenge, COLLECTION_PATH)
 
     suspend fun getById(id: String) =
-        store.getObjectByIdFromCollection<Challenge>(id, COLLECTION_PATH)
+        store.getObjectByIdFromCollection(id, COLLECTION_PATH) {
+            Challenge(
+                it.data ?: emptyMap()
+            )
+        }
 
     suspend fun update(id: String, challenge: Challenge) =
         store.updateObjectInCollection(id, challenge, COLLECTION_PATH)

--- a/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/EventRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/EventRepository.kt
@@ -10,7 +10,9 @@ class EventRepository(private val store: FirebaseFirestore = FirebaseFirestore.g
     suspend fun add(event: Event) =
         store.addObjectToCollection(event, COLLECTION_PATH)
 
-    suspend fun getById(id: String) = store.getObjectByIdFromCollection<Event>(id, COLLECTION_PATH)
+    suspend fun getById(id: String) = store.getObjectByIdFromCollection(id, COLLECTION_PATH) {
+        Event(it.data ?: emptyMap())
+    }
 
     suspend fun getAll() = store.getAllObjectsFromCollection<Event>(COLLECTION_PATH)
 }


### PR DESCRIPTION
I adapted the firebase utility functions to be able to use custom mappers. @Tachi-67 The mapping should actually happen in the repositories and not in the data classes. Unfortunately, I didn't have time to refactor this.