### PR TITLE
Increase image size limit to 10mb

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/RecipeRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/RecipeRepository.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.withContext
 
 private const val COLLECTION_PATH = "recipes"
 private const val STORAGE_BASE_PATH = "/images/recipes"
-private const val ONE_MEGABYTE: Long = 1024 * 1024
+private const val TEN_MEGABYTES: Long = 10 * 1024 * 1024
 
 class RecipeRepository(
     private val store: FirebaseFirestore = FirebaseFirestore.getInstance(),
@@ -40,7 +40,7 @@ class RecipeRepository(
     suspend fun getRecipeImage(id: String) =
         try {
             withContext(Dispatchers.IO) {
-                val bytes = getImageReference(id).getBytes(ONE_MEGABYTE).await()
+                val bytes = getImageReference(id).getBytes(TEN_MEGABYTES).await()
                 bytes
             }
         } catch (e: StorageException) {

--- a/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/TupperwareRepository.kt
+++ b/app/src/main/java/ch/epfl/sdp/cook4me/persistence/repository/TupperwareRepository.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.tasks.await
 
 private const val COLLECTION_PATH = "tupperwares"
 private const val STORAGE_BASE_PATH = "/images/tupperwares"
-private const val ONE_MEGABYTE: Long = 1024 * 1024
+private const val TEN_MEGABYTES: Long = 10 * 1024 * 1024
 
 class TupperwareRepository(
     private val store: FirebaseFirestore = FirebaseFirestore.getInstance(),
@@ -32,7 +32,7 @@ class TupperwareRepository(
     suspend fun getWithImageById(id: String): TupperwareWithImage? {
         val tupperwareInfo = getById(id)
         return tupperwareInfo?.let {
-            val bytes = getImageReference(id).getBytes(ONE_MEGABYTE).await()
+            val bytes = getImageReference(id).getBytes(TEN_MEGABYTES).await()
             TupperwareWithImage(
                 title = it.title,
                 description = it.description,


### PR DESCRIPTION
This PR increases the max image size to 10mb, so images taken by modern smartphones also are shown in the recipe feed and in the tupperware swipe feature. (10mb is too much, but that way we're on the safe side and cover all cameras)